### PR TITLE
recipe fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
 
 
-version = '1.18.2-1.0.0'
+version = '1.18.2-1.0.1'
 group = 'com.alertblock' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'alertblock'
 

--- a/src/main/resources/data/alertblock/recipes/proximity_alert_block.json
+++ b/src/main/resources/data/alertblock/recipes/proximity_alert_block.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "iSi",
+    "iOi",
     "RER",
     "iii"
   ],
@@ -9,8 +9,8 @@
     "i": {
       "item": "minecraft:iron_ingot"
     },
-    "S": {
-      "item": "minecraft:sculk"
+    "O": {
+      "item": "minecraft:obsidian"
     },
     "R": {
       "item": "minecraft:redstone"


### PR DESCRIPTION
**Changes**
- proximity alert block recipe now uses obsidian instead of (non-existent in this version) sculk